### PR TITLE
[Feat] ThemeProvider 추가

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,13 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import App from './App.jsx';
+import { ThemeProvider } from 'styled-components';
+import { theme } from './styles/theme.js';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
   </StrictMode>
 );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,14 @@
+import { useTheme } from 'styled-components';
+
 //메인 페이지
 const Home = () => {
-  return <div>Home</div>;
+  const { colors } = useTheme();
+
+  return (
+    <div style={{ color: colors.primary, background: colors.accentLight }}>
+      Home
+    </div>
+  );
 };
 
 export default Home;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,0 +1,14 @@
+export const theme = {
+  colors: {
+    primary: '#c21d03',
+    primaryLight: '#fd5732',
+    primaryLighter: '#ffb787',
+    accent: '#393939',
+    accentLight: '#bebebe',
+    text: '#232121',
+    textSecondary: '#4b4848',
+    bg: '#fbfbfb',
+    bgLight: '#f1f1f1',
+    bgDark: '#c8c8c8',
+  },
+};


### PR DESCRIPTION

전역 상태에서 공유할 색상들을 theme.js에 정의하고
ThemeProvider를 통해 전역에서 사용할 수 있도록 코드 추가하였습니다.
Home.jsx에 사용 예시 적용해 두었으니 확인 부탁드립니다!
[색상 참고 자료](https://aicolors.co/)