### PR TITLE
"feat : #1 헤더 기본디자인과 대략적인이동기능구현"

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,7 +1,63 @@
+import { Link } from 'react-router-dom';
+import styled, { useTheme } from 'styled-components';
+
 export const Header = () => {
+  const {
+    colors: { primaryLight },
+  } = useTheme();
+  console.log(primaryLight);
   return (
-    <>
-      <div className=''>header</div>
-    </>
+    <StHeader $primaryLight={primaryLight}>
+      <header>
+        <div className='header-home-area'>
+          <Link to='/'>
+            <img src='mm_logo.svg' />
+          </Link>
+          <Link to='/'>
+            <div className='header-title'>MealMate</div>
+          </Link>
+        </div>
+        <div className='header-mypage-area'>
+          {/* 유저정보에따라 login mypage이동 */}
+          <Link to='/mypage'>
+            <div>마이페이지,로그인창 이동영역</div>
+          </Link>
+        </div>
+      </header>
+    </StHeader>
   );
 };
+
+const StHeader = styled.div`
+  background-color: ${(props) => props.$primaryLight};
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 60px;
+  width: 100%;
+  z-index: 1000;
+  a {
+    text-decoration: none;
+    color: inherit;
+    outline: none;
+    cursor: pointer;
+  }
+  header {
+    display: flex;
+    justify-content: space-between;
+  }
+  .header-home-area {
+    display: flex;
+  }
+  .header-home-area img {
+    width: 60px;
+  }
+  .header-title {
+    padding: 13px 5px;
+    font-size: 30px;
+  }
+  .header-mypage-area {
+    background-color: green;
+    height: 60px;
+  }
+`;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -5,20 +5,30 @@ import SignUp from '../pages/SignUp';
 import MyPage from '../pages/MyPage';
 import Detail from '../pages/Detail';
 import PostEditor from '../pages/PostEditor';
+import { Header } from '../components/common/Header';
+import styled from 'styled-components';
 
 const Router = () => {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path='/' element={<Home />} />
-        <Route path='/login' element={<LogIn />} />
-        <Route path='/signup' element={<SignUp />} />
-        <Route path='/mypage' element={<MyPage />} />
-        <Route path='/detail' element={<Detail />} />
-        <Route path='/posteditior' element={<PostEditor />} />
-      </Routes>
+      <Header />
+      <StRouter>
+        <Routes>
+          <Route path='/' element={<Home />} />
+          <Route path='/login' element={<LogIn />} />
+          <Route path='/signup' element={<SignUp />} />
+          <Route path='/mypage' element={<MyPage />} />
+          <Route path='/detail' element={<Detail />} />
+          <Route path='/posteditior' element={<PostEditor />} />
+        </Routes>
+      </StRouter>
     </BrowserRouter>
   );
 };
+
+//Header네비바 영역에 안 덮혀지기 작성해놓은 스타일입니다.
+const StRouter = styled.div`
+  padding-top: 60px;
+`;
 
 export default Router;


### PR DESCRIPTION
1. 헤더의 대략적인 디자인과 로고, 이름을 누를시 home으로 이동하는 기능을 구현해 두었습니다.

2. 나중에 쓰일 마이페이지,로그인 페이지의 표시영역과 링크기능을 대략적으로 표시해두었습니다.

3. header에 영역에 페이지의 내용이 겹치지 않게 하기위해 Router컴포넌트에 스타일을 적용하였습니다.  

![image](https://github.com/user-attachments/assets/975cf514-5128-4822-850b-5043b6688750)
