### PR TITLE
[Feat] alert 공통화 처리

### DIFF
--- a/src/constants/alertConstant.js
+++ b/src/constants/alertConstant.js
@@ -1,0 +1,6 @@
+// 팝업 타입
+export const ALERT_TYPE = Object.freeze({
+  SUCCESS: 'success',
+  ERROR: 'error',
+  WARNING: 'warning',
+});

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,37 @@
+import { ALERT_TYPE } from '../constants/alertConstant';
+import { alert } from '../utils/alert';
+
 //메인 페이지
 const Home = () => {
-  return <div>Home</div>;
+  const { SUCCESS, ERROR, WARNING } = ALERT_TYPE;
+  const successAlert = alert();
+  const errorAlert = alert();
+  const warningAlert = alert();
+
+  return (
+    <div>
+      Home
+      <button
+        onClick={() => successAlert({ type: SUCCESS, content: 'ㅊㅋㅊㅋ' })}
+      >
+        성공
+      </button>
+      <button
+        onClick={() =>
+          errorAlert({ type: ERROR, content: 'ㄴㄴ', buttonText: '닫기' })
+        }
+      >
+        실패
+      </button>
+      <button
+        onClick={() =>
+          warningAlert({ type: WARNING, content: '~를 삭제하시겠습니까?' })
+        }
+      >
+        경고
+      </button>
+    </div>
+  );
 };
 
 export default Home;

--- a/src/utils/alert.js
+++ b/src/utils/alert.js
@@ -1,0 +1,50 @@
+import Swal from 'sweetalert2';
+import { ALERT_TYPE } from '../constants/alertConstant';
+
+const { SUCCESS, WARNING, ERROR } = ALERT_TYPE;
+
+export const alert = () => {
+  const createAlert = (alertInfo) => {
+    const { type, content, buttonText } = alertInfo;
+    const alertType = {
+      [ERROR]: {
+        type: ERROR,
+        title: 'Error!',
+        content: content || '에러가 발생했습니다.',
+        buttonText: buttonText || '확인',
+        buttonColor: 'rgb(238, 76, 76)',
+      },
+      [SUCCESS]: {
+        type: SUCCESS,
+        title: 'Success!',
+        content: content || '완료되었습니다.',
+        buttonText: buttonText || '확인',
+        buttonColor: 'rgb(133, 215, 92)',
+      },
+      [WARNING]: {
+        type: WARNING,
+        title: 'Warning!',
+        content: content || '다시 확인해 주세요.',
+        buttonText: buttonText || '확인',
+        showCancelButton: true,
+        buttonColor: 'rgb(245, 170, 104)',
+      },
+    };
+
+    const alert = alertType[type] || alertType[SUCCESS];
+
+    return Swal.fire({
+      title: alert.title,
+      text: alert.content,
+      icon: alert.type,
+      confirmButtonText: alert.buttonText,
+      confirmButtonColor: alert.buttonColor,
+      showCancelButton: alert.showCancelButton ?? null,
+      cancelButtonText: '취소',
+    });
+  };
+
+  return (alertInfo) => {
+    createAlert(alertInfo);
+  };
+};


### PR DESCRIPTION

우리 팀은 sweetAlert2로 alert 처리를 하기로 하였습니다.
하지만 사용할 때 마다 
Swal.fire({
      title:title,
      text:content,
      icon:type,
      confirmButtonText:buttonText,
      confirmButtonColor:buttonColor,
      showCancelButton: alert.showCancelButton ?? null,
      cancelButtonText: '취소',
    });
이런식으로 작성하면 코드가 지저분해지는 한계점이 있습니다.
따라서 alert.js에 따로 분리하였습니다.

type, content, buttonText정도만 넘겨 받아서 alert를 만들도록 하였고
아직까지는 성공, 에러, 경고 정도만 있으면 충분할 거 같아서 3가지 alert만 작업했습니다.

혹시 추가로 더 커스터마이징 하고 싶으신 거 있으시면 추가해 주세요~!
예시는 Home.jsx에서 확인 부탁드립니다~ 
