### PR TITLE
Feat/user posts 해당 유저가 작성한 게시물을 띄우는 페이지

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -12,9 +12,8 @@ export const AuthProvider = ({ children }) => {
   //로그인상태(isLogin)와 로그인한유저(loggedInUser)는 세션에서 받아옵니다.
   //isLogin 세션스토리에 값이 있으면 true 없으면 false가 됩니다.
   const [isLogin, setIsLogin] = useState(!!sessionStorage.getItem('isLogin'));
-  const loggedInUser = useRef(
-    JSON.parse(sessionStorage.getItem('loggedInUser')) || 'anon'
-  );
+  const loggedInUser =
+    JSON.parse(sessionStorage.getItem('loggedInUser')) || 'anon';
 
   //일단 로그인을 위해 id비밀번호 문자열로 넣어두겠습니다!
   //닉네임 장현빈(님) 과 연결되어 있는 id비밀번호입니다.
@@ -25,15 +24,18 @@ export const AuthProvider = ({ children }) => {
     const getUserInfo = async () => {
       const {
         data: { user },
-        errorSignUp,
       } = await supabase.auth.signInWithPassword({
         email: userEmail,
         password: userPassword,
       });
-      if (errorSignUp) {
-        errorAlert({ type: ERROR, content: '로그인실패 아이디 비밀번호 다름' });
+      if (user === null) {
+        errorAlert({
+          type: ERROR,
+          content: '로그인 실패 :: 아이디 비밀번호를 확인하세요',
+        });
         return;
       }
+
       authUserId = user.id;
       //받아온 auth_Id로 해당유저의 public 유저 정보 가져옴
       const { data, errorFetchUserData } = await supabase
@@ -41,8 +43,8 @@ export const AuthProvider = ({ children }) => {
         .select('*')
         .eq('id', authUserId)
         .single();
-      if (errorFetchUserData) {
-        errorAlert({ type: ERROR, content: '서버에러' });
+      if (data === null) {
+        errorAlert({ type: ERROR, content: '로그인요청오류' });
         return;
       }
 
@@ -54,7 +56,7 @@ export const AuthProvider = ({ children }) => {
       setIsLogin(!!user);
     };
 
-    if (!isLogin) getUserInfo();
+    getUserInfo();
   }, []);
   //useEffact 부분 잘라내고 폼 제출시 발생하는 이벤트 핸들러에 넣으면 될 거 같아요
 

--- a/src/pages/UserPosts.jsx
+++ b/src/pages/UserPosts.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import PostCard from '../components/home/PostCard';
+import { supabase } from '../supabase/client';
+import { alert } from '../utils/alert';
+import { ALERT_TYPE } from '../constants/alertConstant';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+const UserPosts = () => {
+  const isLogin = '로그인이되어있습니다.';
+
+  //sweet Alert
+  const errorAlert = alert();
+  const { ERROR } = ALERT_TYPE;
+
+  const [posts, setPosts] = useState([]);
+
+  //패치파라미터로 유저닉네임 가져오기
+  const { userNickname } = useParams();
+  const navigate = useNavigate();
+
+  //로그인이 안되어 있으면 로그인 페이지로 이동
+  if (!isLogin) {
+    errorAlert({
+      type: ERROR,
+      content: '로그인이 필요합니다. 로그인 페이지로 이동합니다.',
+    });
+
+    setTimeout(() => {
+      navigate('/login');
+    }, 0);
+  }
+
+  useEffect(() => {
+    //받아온 닉네임을 기준으로 포스트리스트에서  가져오기
+    const getPosts = async () => {
+      const { data, error } = await supabase
+        .from('posts')
+        .select('*')
+        .eq('author_name', userNickname);
+      setPosts(data);
+
+      if (error) errorAlert({ type: ERROR, content: error.message });
+    };
+    if (isLogin) getPosts();
+  }, []);
+
+  return (
+    <StUserPostsWrapper>
+      <div className='postCards'>
+        {posts.map((data) => (
+          <PostCard key={`post_${data.id}`} postData={data} />
+        ))}
+      </div>
+    </StUserPostsWrapper>
+  );
+};
+
+const StUserPostsWrapper = styled.div`
+  padding-top: 20px;
+  .postCards {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px;
+  }
+`;
+
+export default UserPosts;

--- a/src/pages/UserPosts.jsx
+++ b/src/pages/UserPosts.jsx
@@ -1,35 +1,42 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PostCard from '../components/home/PostCard';
 import { supabase } from '../supabase/client';
 import { alert } from '../utils/alert';
 import { ALERT_TYPE } from '../constants/alertConstant';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import AuthContext from '../context/AuthContext';
 
 const UserPosts = () => {
-  const isLogin = '로그인이되어있습니다.';
+  const { isLogin, loggedInUser } = useContext(AuthContext);
 
   //sweet Alert
   const errorAlert = alert();
   const { ERROR } = ALERT_TYPE;
-
-  const [posts, setPosts] = useState([]);
 
   //패치파라미터로 유저닉네임 가져오기
   const { userNickname } = useParams();
   const navigate = useNavigate();
 
   //로그인이 안되어 있으면 로그인 페이지로 이동
-  if (!isLogin) {
+  if (isLogin) {
     errorAlert({
       type: ERROR,
       content: '로그인이 필요합니다. 로그인 페이지로 이동합니다.',
+    }).then((res) => {
+      if (res.isConfirmed) navigate('/login', { replace: true });
     });
-
-    setTimeout(() => {
-      navigate('/login');
-    }, 0);
+    return <></>;
   }
+
+  //로그인한 유저가 자신의 프로필을 클릭했을시
+  if (loggedInUser.nick_name === userNickname) {
+    navigate('/mypage/my-posts', { replace: true });
+    return <></>;
+  }
+
+  //받아온 포스트를 저장하는 state
+  const [posts, setPosts] = useState([]);
 
   useEffect(() => {
     //받아온 닉네임을 기준으로 포스트리스트에서  가져오기

--- a/src/pages/UserPosts.jsx
+++ b/src/pages/UserPosts.jsx
@@ -9,34 +9,16 @@ import AuthContext from '../context/AuthContext';
 
 const UserPosts = () => {
   const { isLogin, loggedInUser } = useContext(AuthContext);
-
-  //sweet Alert
-  const errorAlert = alert();
-  const { ERROR } = ALERT_TYPE;
+  //받아온 포스트를 저장하는 state
+  const [posts, setPosts] = useState([]);
 
   //패치파라미터로 유저닉네임 가져오기
   const { userNickname } = useParams();
   const navigate = useNavigate();
 
-  //로그인이 안되어 있으면 로그인 페이지로 이동
-  if (isLogin) {
-    errorAlert({
-      type: ERROR,
-      content: '로그인이 필요합니다. 로그인 페이지로 이동합니다.',
-    }).then((res) => {
-      if (res.isConfirmed) navigate('/login', { replace: true });
-    });
-    return <></>;
-  }
-
-  //로그인한 유저가 자신의 프로필을 클릭했을시
-  if (loggedInUser.nick_name === userNickname) {
-    navigate('/mypage/my-posts', { replace: true });
-    return <></>;
-  }
-
-  //받아온 포스트를 저장하는 state
-  const [posts, setPosts] = useState([]);
+  //sweet Alert
+  const errorAlert = alert();
+  const { ERROR } = ALERT_TYPE;
 
   useEffect(() => {
     //받아온 닉네임을 기준으로 포스트리스트에서  가져오기
@@ -51,6 +33,23 @@ const UserPosts = () => {
     };
     if (isLogin) getPosts();
   }, []);
+
+  //로그인이 안되어 있으면 로그인 페이지로 이동
+  if (!isLogin) {
+    errorAlert({
+      type: ERROR,
+      content: '로그인이 필요합니다. 로그인 페이지로 이동합니다.',
+    }).then((res) => {
+      if (res.isConfirmed) navigate('/login', { replace: true });
+    });
+    return <></>;
+  }
+
+  //로그인한 유저가 자신의 프로필을 클릭했을시
+  if (loggedInUser.nick_name === userNickname) {
+    navigate('/mypage/my-posts', { replace: true });
+    return <></>;
+  }
 
   return (
     <StUserPostsWrapper>

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -9,6 +9,7 @@ import { Layout } from '../components/common/Layout';
 import { EditProfile } from '../components/mypage/EditProfile';
 import { MyPosts } from '../components/mypage/MyPosts';
 import { JoinedPosts } from '../components/mypage/JoinedPosts';
+import UserPosts from '../pages/UserPosts';
 
 const Router = () => {
   return (
@@ -25,6 +26,7 @@ const Router = () => {
           </Route>
           <Route path='/detail' element={<Detail />} />
           <Route path='/posteditior' element={<PostEditor />} />
+          <Route path='/user-posts/:userNickname' element={<UserPosts />} />
         </Routes>
       </Layout>
     </BrowserRouter>


### PR DESCRIPTION
## 📌 변경 사항
1. Route 컴포넌트를 수정하였습니다.
2. user-posts 컴포넌트를 새로 만들었습니다. 

## 🔗 관련 이슈
- Feat #34

## 🛠️ 변경 이유 및 설명
#### 변경이유
1. user-posts페이지로 이동을 하기위해 Route 컴포넌트를 수정하였습니다.
2. 해당유저의 게시물을 띄우기 위해 pages 폴더안에 user-posts 컴포넌트를 새로 만들었습니다. 
3. 로그인한 유저가 자신의 user-posts페이지를 요청하면 mypage의 게시물 목록이로 이동시키게 만들었습니다.
#### 설명
- user-posts는 페치파라미터의 닉네임을 기준으로 해당 유저의 게시물을 띄우는 컴포넌트입니다.

- 해당하는 유저의 게시물을 띄우려면 아래의 링크로 이동 시켜주시면 됩니다
```
/user-posts/'유저닉네임' 
```

- 로그인이 안 되어 있을 시 해당유저의 게시물을 조회하지 않고, 로그인이 필요하다는 알럿과 함께 로그인페이지로 이동합니다.

- 게시물 카드는 다혜님의 이 작성해주신 home/PostsCard.jsx를 이용하였습니다. 
## ✅ 체크리스트
- [x] 관련된 이슈가 있습니다.
- [x] 코드가 정상적으로 동작합니다.
- [x] 테스트를 거쳤습니다.

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/865fc136-66b1-4625-bb3c-c6579625ee6a)
![image](https://github.com/user-attachments/assets/ab0c3a82-4507-4282-a836-e7108d263694)

