### PR TITLE
Feat/login status context : 로그인상태와, 로그인한 유저의 id를 전달해주는 context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,12 @@
 import Router from './routes/Router';
-
+import { AuthProVider } from './context/AuthContext';
 //app.jsx
 function App() {
   return (
     <>
-      <Router />
+      <AuthProVider>
+        <Router />
+      </AuthProVider>
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,12 @@
 import Router from './routes/Router';
-import { AuthProVider } from './context/AuthContext';
+import { AuthProvider } from './context/AuthContext';
 //app.jsx
 function App() {
   return (
     <>
-      <AuthProVider>
+      <AuthProvider>
         <Router />
-      </AuthProVider>
+      </AuthProvider>
     </>
   );
 }

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -14,19 +14,18 @@ export const AuthProVider = ({ children }) => {
 
   //일단 로그인을 위해 id비밀번호 문자열로 넣어두겠습니다!
   //닉네임 장현빈(님) 과 연결되어 있는 id비밀번호입니다.
-  const [supabaseRequestId, setSupabaseRequestId] = useState('pal@naver.com');
-  const [supabaseRequestPassword, setSupabaseRequestPassword] =
-    useState('1234');
+  const [userEmail, setUserEmail] = useState('pal@naver.com');
+  const [userPassword, setUserPassword] = useState('1234');
 
   useEffect(() => {
     let authUserId = '';
-    const signUp = async () => {
+    const getUserInfo = async () => {
       const {
         data: { user },
         errorSignUp,
       } = await supabase.auth.signInWithPassword({
-        email: supabaseRequestId,
-        password: supabaseRequestPassword,
+        email: userEmail,
+        password: userPassword,
       });
       if (errorSignUp) {
         errorAlert({ type: ERROR, content: '로그인실패 아이디 비밀번호 다름' });
@@ -45,7 +44,7 @@ export const AuthProVider = ({ children }) => {
       }
       setAuthUserId(data);
     };
-    signUp();
+    getUserInfo();
   }, []);
   //여기 부분은 로그인 페이지에 있는게 맞는 것 같긴합니다 일단 로그인을 위해 여기에 작성합니다~~
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -10,6 +10,7 @@ export const AuthProVider = ({ children }) => {
   const errorAlert = alert();
 
   const [isLogin, setIsLogin] = useState(false);
+  const [authUserId, setAuthUserId] = useState('anon');
 
   //일단 로그인을 위해 id비밀번호 문자열로 넣어두겠습니다!
   //닉네임 장현빈(님) 과 연결되어 있는 id비밀번호입니다.
@@ -19,19 +20,25 @@ export const AuthProVider = ({ children }) => {
 
   useEffect(() => {
     const signUp = async () => {
-      const { data, error } = await supabase.auth.signInWithPassword({
+      const {
+        data: { user },
+        error,
+      } = await supabase.auth.signInWithPassword({
         email: supabaseRequestId,
         password: supabaseRequestPassword,
       });
-      if (error) errorAlert({ type: ERROR, content: error.message });
-      setIsLogin(data);
+      if (error) errorAlert({ type: ERROR, content: '로그인실패' });
+      setIsLogin(!!user);
+      setAuthUserId(user?.id || 'anon');
     };
     signUp();
   }, []);
-  //여기 부분은 로그인 페이지에 있는게 맞는 것 같긴합니다 일단 로그인 로직을 위해 여기에 작성합니다~~
+  //여기 부분은 로그인 페이지에 있는게 맞는 것 같긴합니다 일단 로그인을 위해 여기에 작성합니다~~
 
   return (
-    <AuthContext.Provider value={{ isLogin }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={{ isLogin, authUserId }}>
+      {children}
+    </AuthContext.Provider>
   );
 };
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,38 @@
+import { useState, useEffect, createContext } from 'react';
+import { supabase } from '../supabase/client';
+import { alert } from '../utils/alert';
+import { ALERT_TYPE } from '../constants/alertConstant';
+
+const AuthContext = createContext(null);
+
+export const AuthProVider = ({ children }) => {
+  const { ERROR } = ALERT_TYPE;
+  const errorAlert = alert();
+
+  const [isLogin, setIsLogin] = useState(false);
+
+  //일단 로그인을 위해 id비밀번호 문자열로 넣어두겠습니다!
+  //닉네임 장현빈(님) 과 연결되어 있는 id비밀번호입니다.
+  const [supabaseRequestId, setSupabaseRequestId] = useState('pal@naver.com');
+  const [supabaseRequestPassword, setSupabaseRequestPassword] =
+    useState('1234');
+
+  useEffect(() => {
+    const signUp = async () => {
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email: supabaseRequestId,
+        password: supabaseRequestPassword,
+      });
+      if (error) errorAlert({ type: ERROR, content: error.message });
+      setIsLogin(data);
+    };
+    signUp();
+  }, []);
+  //여기 부분은 로그인 페이지에 있는게 맞는 것 같긴합니다 일단 로그인 로직을 위해 여기에 작성합니다~~
+
+  return (
+    <AuthContext.Provider value={{ isLogin }}>{children}</AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -10,7 +10,7 @@ export const AuthProVider = ({ children }) => {
   const errorAlert = alert();
 
   const [isLogin, setIsLogin] = useState(false);
-  const [authUserId, setAuthUserId] = useState('anon');
+  const [loggedInUser, setAuthUserId] = useState('anon');
 
   //일단 로그인을 위해 id비밀번호 문자열로 넣어두겠습니다!
   //닉네임 장현빈(님) 과 연결되어 있는 id비밀번호입니다.
@@ -19,24 +19,38 @@ export const AuthProVider = ({ children }) => {
     useState('1234');
 
   useEffect(() => {
+    let authUserId = '';
     const signUp = async () => {
       const {
         data: { user },
-        error,
+        errorSignUp,
       } = await supabase.auth.signInWithPassword({
         email: supabaseRequestId,
         password: supabaseRequestPassword,
       });
-      if (error) errorAlert({ type: ERROR, content: '로그인실패' });
+      if (errorSignUp) {
+        errorAlert({ type: ERROR, content: '로그인실패 아이디 비밀번호 다름' });
+        return;
+      }
       setIsLogin(!!user);
-      setAuthUserId(user?.id || 'anon');
+      authUserId = user.id;
+      //받아온 auth_Id로 해당유저의 public 유저 정보 가져옴
+      const { data, errorFetchUserData } = await supabase
+        .from('users')
+        .select('*')
+        .eq('id', authUserId)
+        .single();
+      if (errorFetchUserData) {
+        errorAlert({ type: ERROR, content: '서버에러' });
+      }
+      setAuthUserId(data);
     };
     signUp();
   }, []);
   //여기 부분은 로그인 페이지에 있는게 맞는 것 같긴합니다 일단 로그인을 위해 여기에 작성합니다~~
 
   return (
-    <AuthContext.Provider value={{ isLogin, authUserId }}>
+    <AuthContext.Provider value={{ isLogin, loggedInUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -5,7 +5,7 @@ import { ALERT_TYPE } from '../constants/alertConstant';
 
 const AuthContext = createContext(null);
 
-export const AuthProVider = ({ children }) => {
+export const AuthProvider = ({ children }) => {
   const { ERROR } = ALERT_TYPE;
   const errorAlert = alert();
 


### PR DESCRIPTION
## 📌 변경 사항
1. context/AuthContext.jsx 파일생성
2. App.jsx 변경

## 🔗 관련 이슈
- Resolved: #18

## 🛠️ 변경 이유 및 설명
#### 변경이유
1. 로그인 상태와, 로그인한 유저의 식별 id를 전달해주는 AuthContext파일을 만들었습니다.
2. AuthContext를 전역에 주입시켜주기 위해 App.jsx파일을 변경하였습니다.
#### 설명
- 단순히 상태만 내려주고 확인하여 사용하기 위해, AuthContext폴더안에 문자열로 Id,Password를 입력해 두었습니다. 로그인 실패상태가 필요하면 AuthContext의 비밀번호를 틀리게 바꾸시면 됩니다.
```
const { isLogin, authUserId } = useContext(AuthContext);
//로그인 성공시
  console.log(isLogin); >> true
  console.log(authUserId); >> "c712d979-726f-4101-a794-519d5ff79c09"
//로그인실패 시
  console.log(isLogin); >> false
  console.log(authUserId); >> "anon"
```

#### 수정이 필요한부분
- **context안에 로그인정보를 요청하는 로직을 작성해 두었습니다. 나중에 로그인 창으로 해당 로직을 옮겨야 할 것 같습니다.** 
- 로그인 실패시 뜨는 알럿도 넣어두었는데 수정이 필요할 것 같습니다.
-  세션을 사용하는 경우가 어떤때인지 몰라 일단 유저의 id만 뽑아서 전달되게 작성해 두었습니다. 세션정보 등을 사용해야 한다면 수정이 필요 할 것 같습니다.

## ✅ 체크리스트
<!-- 아래 사항을 확인하고 체크해주세요. -->
- [x] 관련된 이슈가 있습니다.
- [x] 코드가 정상적으로 동작합니다.
- [x] 테스트를 거쳤습니다.
- [ ] 문서화가 필요한 경우, 문서를 작성했습니다.

## 📸 스크린샷 (선택)
마이페이지에서 상태값을 불러와 사용해보았습니다.
![Screenshot 2025-02-15 210031](https://github.com/user-attachments/assets/6747b80c-eade-4de8-8008-fc44091e58b6)

![Screenshot 2025-02-15 210333](https://github.com/user-attachments/assets/2d4a41ff-e55c-4647-9b83-e55268640b3d)

400은 비밀번호가 달라서 뜨는 오류 같습니다.