### PR TITLE
feat: 사용자 로그인 상태에 따라 게시글 좋아요 기능 및 댓글 기능 개선

### DIFF
--- a/src/components/detail/CommentSection.jsx
+++ b/src/components/detail/CommentSection.jsx
@@ -1,10 +1,249 @@
-export const CommentSection = () => {
+import { useEffect, useState } from 'react';
+import { supabase } from '../../supabase/client';
+import styled from 'styled-components';
 
-    return(
-        <div> 
-           <p>댓글창</p>
-           <input></input>
-           
-        </div>
-    )
-}
+export const CommentSection = ({ postId }) => {
+  const [comments, setComments] = useState([]);
+  const [commentText, setCommentText] = useState('');
+  const [userId, setUserId] = useState(null);
+  const [nickName, setNickName] = useState('');
+
+  // 처음 로딩 때 사용자 정보(사용자 ID 및 닉네임)를 가져옵니다.
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        // Supabase로 사용자 정보 가져오기
+        const { data: { user }, error } = await supabase.auth.getUser();
+        if (error || !user) throw new Error('로그인 필요');
+
+        // 가져온 사용자 ID를 상태에 저장
+        setUserId(user.id);
+
+        // 사용자 테이블(users)에서 사용자 닉네임 가져오기
+        const { data: userInfo, error: userError } = await supabase
+          .from('users')
+          .select('nick_name')
+          .eq('id', user.id)
+          .single();
+
+        if (userError) throw new Error(`닉네임 조회 실패: ${userError.message}`);
+        setNickName(userInfo.nick_name);
+      } catch (error) {
+        console.error('유저 정보 가져오기 실패:', error.message);
+      }
+    };
+
+    fetchUser();
+  }, []);
+
+  // 지정된 postId에 속한 댓글을 가져와서 상태에 설정합니다.
+  const fetchComments = async () => {
+    try {
+      // Supabase에서 comments 테이블 조회
+      const { data, error } = await supabase
+        .from('comments')
+        .select('*')
+        .eq('post_id', postId)
+        .order('created_at', { ascending: false });
+
+      if (error) throw new Error(`댓글 불러오기 실패: ${error.message}`);
+      setComments(data);
+    } catch (error) {
+      console.error('댓글 가져오기 실패:', error.message);
+    }
+  };
+
+  // postId 변경 시 댓글을 불러옵니다.
+  useEffect(() => {
+    if (postId) fetchComments();
+  }, [postId]);
+
+  // 사용자가 입력한 내용을 바탕으로 새로운 댓글을 추가합니다.
+  const handleAddComment = async () => {
+    // 댓글이 비어 있는지 확인
+    if (!commentText.trim()) {
+      alert('첫 댓글 입력해 보세요~!');
+      return;
+    }
+
+    // 로그인되지 않은 사용자 차단
+    if (!userId) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
+
+    try {
+      // comments 테이블에 새 댓글 삽입
+      const { error } = await supabase
+        .from('comments')
+        .insert([{ 
+          post_id: postId, 
+          user_id: userId, 
+          nick_name: nickName, 
+          content: commentText 
+        }]);
+
+      if (error) throw new Error(`댓글 추가 실패: ${error.message}`);
+
+      // 입력 필드 초기화 후 댓글 새로고침
+      setCommentText('');
+      fetchComments();
+    } catch (error) {
+      console.error('댓글 추가 실패:', error.message);
+    }
+  };
+
+  // 댓글을 삭제하는 함수
+  const handleDeleteComment = async (commentId) => {
+    // 삭제 확인 메시지를 사용자에게 표시
+    const confirmDelete = window.confirm('정말로 이 댓글을 삭제하시겠습니까?');
+    if (!confirmDelete) return;
+
+    try {
+      // Supabase에서 지정된 ID의 댓글 삭제
+      const { error } = await supabase
+        .from('comments')
+        .delete()
+        .eq('id', commentId);
+
+      if (error) throw new Error(`댓글 삭제 실패: ${error.message}`);
+
+      alert('댓글이 삭제되었습니다.');
+      // 삭제 후 최신 댓글 목록을 다시 불러옴
+      fetchComments();
+    } catch (error) {
+      console.error('댓글 삭제 실패:', error.message);
+    }
+  };
+
+  return (
+    <CommentContainer>
+      {/* 댓글 입력 폼 */}
+      <InputContainer>
+        <input
+          type="text"
+          placeholder="댓글을 입력하세요..."
+          value={commentText}
+          onChange={(e) => setCommentText(e.target.value)}
+          disabled={!userId}
+        />
+        <button onClick={handleAddComment} disabled={!userId}>
+          댓글 작성
+        </button>
+      </InputContainer>
+
+      {/* 댓글 리스트 */}
+      <CommentList>
+        {comments.length > 0 ? (
+          comments.map((comment) => (
+            <CommentItem key={comment.id}>
+              <CommentHeader>
+                <strong>{comment.nick_name || '익명'}</strong>
+                {/* 현재 로그인한 사용자와 댓글 작성자가 일치할 때만 삭제 버튼 표시 */}
+                {comment.user_id === userId && (
+                  <DeleteButton onClick={() => handleDeleteComment(comment.id)}>
+                    삭제
+                  </DeleteButton>
+                )}
+              </CommentHeader>
+              <p>{comment.content}</p>
+              <span>{new Date(comment.created_at).toLocaleString()}</span>
+            </CommentItem>
+          ))
+        ) : (
+          <p>댓글이 없습니다.</p>
+        )}
+      </CommentList>
+    </CommentContainer>
+  );
+};
+
+// 스타일 정의
+const CommentContainer = styled.div`
+  margin-top: 30px;
+  padding: 20px;
+  background: #f3f3f3;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+`;
+
+const InputContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+
+  input {
+    flex: 1;
+    padding: 10px;
+    font-size: 14px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+
+  button {
+    padding: 10px 15px;
+    font-size: 14px;
+    background-color: #28a745;
+    color: white;
+    border: none;
+    border-radius: 4px;
+
+    &:hover:enabled {
+      background-color: #218838;
+    }
+
+    &:disabled {
+      background-color: #ccc;
+      cursor: not-allowed;
+    }
+  }
+`;
+
+const CommentList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const CommentItem = styled.div`
+  padding: 10px;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+
+  strong {
+    display: block;
+    margin-bottom: 4px;
+    color: #007bff;
+  }
+
+  p {
+    font-size: 14px;
+    color: #333;
+  }
+
+  span {
+    font-size: 12px;
+    color: #777;
+  }
+`;
+
+const CommentHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const DeleteButton = styled.button`
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 6px;
+  cursor: pointer;
+  font-size: 12px;
+
+  &:hover {
+    background-color: #c82333;
+  }
+`;

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,20 +1,67 @@
-import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useEffect, useState, useContext } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import { supabase } from '../supabase/client.js';
 import styled from 'styled-components';
 import dayjs from 'dayjs';
 import { DetailAction } from '../components/detail/DetailAction';
-import { CommentSection } from '../components/detail/CommentSection.jsx';
+import { CommentSection } from '../components/detail/CommentSection';
 import { alert } from '../utils/alert.js';
 import { ALERT_TYPE } from '../constants/alertConstant';
+import AuthContext from '../context/AuthContext.jsx';
 
 export const Detail = () => {
-  // 게시글 데이터 상태
+  // 게시글 데이터와 사용자 ID 상태 관리
   const [post, setPost] = useState(null);
+  const [userId, setUserId] = useState(null);
+
+  // 쿼리 스트링으로 postId 가져오기
   const [searchParams] = useSearchParams();
   const postId = searchParams.get('id');
 
-  // 게시글 데이터를 비동기적으로 가져오는 함수 (try-catch 적용)
+  // 페이지 이동을 위한 navigate 함수
+  const navigate = useNavigate();
+
+  // AuthContext를 통해 로그인 상태 가져오기
+  const { isLogin } = useContext(AuthContext);
+
+  // 스위트 알러트를 사용하기 위한 alert 함수
+  const errorAlert = alert();
+
+  // 디테일 페이지 접속시 로그인 상태 확인
+  useEffect(() => {
+    if (!isLogin) {
+      errorAlert({
+        type: ALERT_TYPE.ERROR,
+        content: '로그인이 필요합니다. 로그인 페이지로 이동합니다.',
+      }).then((res) => {
+        if (res.isConfirmed) navigate('/login', { replace: true });
+      });
+    }
+  }, [isLogin, navigate, errorAlert]);
+
+  // 로그인되지 않았으면 안보여주기
+  if (!isLogin) {
+    return null;
+  }
+
+  // 현재 로그인된 사용자 ID를 가져오는 함수
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const {
+          data: { user },
+          error,
+        } = await supabase.auth.getUser();
+        if (error) throw error;
+        if (user) setUserId(user.id);
+      } catch (error) {
+        console.error('유저 인증 실패:', error);
+      }
+    };
+    fetchUser();
+  }, []);
+
+  // 게시글 데이터 가져오기
   useEffect(() => {
     const fetchPost = async () => {
       try {
@@ -24,60 +71,71 @@ export const Detail = () => {
           .eq('id', postId)
           .single();
 
-        if (error) {
-          throw error;
-        }
+        if (error) throw error;
+
         setPost(data);
       } catch (error) {
-        // 에러 발생시 스왈을 이용하여 에러 표시
-        alert()({
+        errorAlert({
           type: ALERT_TYPE.ERROR,
           content: '게시글을 불러오는 중 오류가 발생했습니다.',
         });
-        console.error('데이터 가져오기 오류:', error);
+        console.error('게시글 가져오기 오류:', error);
       }
     };
 
     if (postId) {
       fetchPost();
     }
-  }, [postId]);
+  }, [postId, errorAlert]);
 
+  // 데이터 로딩 중 표시할 내용
   if (!post) {
     return <p>게시글을 불러오는 중...</p>;
   }
-  // 게시글 화면 렌더링
+
+  // 디테일 페이지 렌더링
   return (
     <StPageContainer>
       <StArticleContainer>
+        {/* 게시글 제목 표시 */}
         <StTitle>{post.post_title}</StTitle>
+
+        {/* 작성자 정보 표시 */}
         <StAuthorInfo>
           작성자: {post.author_name} ·{' '}
-          {dayjs(post.post_date).format('YYYY년 MM월 DD일 HH시 mm분')}
+          {dayjs(post.created_at).format('YYYY년 MM월 DD일 HH시 mm분')}
         </StAuthorInfo>
+
+        {/* 게시글 이미지 표시 */}
         {post.post_img_url && (
           <StImageContainer>
             <img src={post.post_img_url} alt='게시글 이미지' />
           </StImageContainer>
         )}
+
+        {/* 게시글 내용 표시 */}
         <StContent>{post.post_content}</StContent>
+
+        {/* 추가 정보 표시 */}
         <StExtraInfo>
-          <p>❗️ 위치: {post.post_location}</p>
-          <p>📅 날짜: {dayjs(post.post_date).format('YYYY년 MM월 DD일')}</p>
-          <p>⏱️ 시간: {dayjs(post.post_date).format('HH시 mm분')}</p>
-          <p>👍 모집 인원수: {post.post_rec_cnt}</p>
+          <p>🍽️ 메뉴: {post.post_menu}</p>
+          <p>📍 위치: {post.post_location}</p>
+          <p>📆 날짜: {dayjs(post.meeting_date).format('YYYY년 MM월 DD일')}</p>
+          <p>🕒 시간: {dayjs(post.meeting_date).format('HH시 mm분')}</p>
+          <p>👥 모집 인원수: {post.post_rec_cnt}</p>
         </StExtraInfo>
-        {/* 함께해요 버튼 */}
-        <DetailAction postId={postId} userId={'사용자_아이디_여기'} />
-        <CommentSection></CommentSection>
+
+        {/* 좋아요(함께해요) 버튼 */}
+        {userId && <DetailAction postId={postId} userId={userId} />}
+
+        {/* 댓글 섹션 */}
+        <CommentSection postId={postId} />
       </StArticleContainer>
     </StPageContainer>
   );
 };
 
-export default Detail;
-
-// Styled-components
+// 페이지 전체 컨테이너 스타일링
 const StPageContainer = styled.div`
   width: 100vw;
   min-height: 100vh;
@@ -87,16 +145,17 @@ const StPageContainer = styled.div`
   padding: 10px;
 `;
 
+// 게시글 콘텐츠 컨테이너 스타일링
 const StArticleContainer = styled.div`
   width: 100%;
   max-width: 1200px;
   background: #fff;
   padding: 40px;
   border-radius: 8px;
-
   line-height: 1.8;
 `;
 
+// 제목 스타일링
 const StTitle = styled.h1`
   font-size: 32px;
   font-weight: bold;
@@ -104,12 +163,14 @@ const StTitle = styled.h1`
   margin-bottom: 20px;
 `;
 
+// 작성자 정보 스타일링
 const StAuthorInfo = styled.p`
   font-size: 16px;
   color: #777;
   margin-bottom: 20px;
 `;
 
+// 이미지 컨테이너 스타일링
 const StImageContainer = styled.div`
   width: 100%;
   overflow: hidden;
@@ -123,12 +184,14 @@ const StImageContainer = styled.div`
   }
 `;
 
+// 게시글 내용 스타일링
 const StContent = styled.p`
   font-size: 20px;
   color: #444;
   margin-bottom: 20px;
 `;
 
+// 게시글 추가 정보 스타일링
 const StExtraInfo = styled.div`
   font-size: 18px;
   color: #555;
@@ -138,3 +201,5 @@ const StExtraInfo = styled.div`
   border-radius: 4px;
   margin-top: 20px;
 `;
+
+export default Detail;


### PR DESCRIPTION
## 📌 변경 사항
- Home에서 detail 접속 시 비로그인 상태면 로그인이 필요하다는 sweetalert 띄우고 로그인 페이지로 이동시킴
- 좋아요 기능 정상 작동 및 supabase의 actions 테이블에 데이터 저장
- 댓글 기능 정상 작동 및 supabase의 comments 테이블에 데이터 저장 후 댓글리스트에 닉네임과 함께 댓글 표시
- 댓글 삭제 기능 추가(userid 대조하여 내 댓글일때만 삭제 버튼 나타남)
- 약속시간과 게시한 시간이 현재 시간으로 뜨는 오류 수정 완료(posts 테이블의 column 이름이 변경 된 것에 따라 렌더링 코드 수정 완료)
계속 되는 stash 오류로 코드 메모장에 복사 후 final branch를 생성하였습니다

## ✅ 체크리스트
<!-- 아래 사항을 확인하고 체크해주세요. -->
- [ ] 관련된 이슈가 있습니다.
- [ ] 코드가 정상적으로 동작합니다.
- [ ] 테스트를 거쳤습니다.
- [ ] 문서화가 필요한 경우, 문서를 작성했습니다.

## 📸 스크린샷 (선택)
<img width="1470" alt="스크린샷 2025-02-17 오후 5 00 08" src="https://github.com/user-attachments/assets/e6084c0d-8dc1-4ff8-bb85-028e3f8626df" />
<img width="1470" alt="스크린샷 2025-02-17 오후 4 59 04" src="https://github.com/user-attachments/assets/d28300e2-c4a9-40cc-a06d-f3e0127d0954" />

