### PR TITLE
fix : EditProfile 이미지 업로드시 페이지에 반영 안되는 버그 수정

### DIFF
--- a/src/components/mypage/EditProfile.jsx
+++ b/src/components/mypage/EditProfile.jsx
@@ -104,9 +104,6 @@ export const EditProfile = () => {
       }
     }
 
-    setImagePreview('');
-    setSelectedFile('');
-
     //페이지가 새로고침될때 세션스토리지에서 user정보를 가져오기 때문에 세션스토리지도 변경
     sessionStorage.setItem('loggedInUser', JSON.stringify(...data));
 
@@ -116,6 +113,10 @@ export const EditProfile = () => {
       type: SUCCESS,
       content: '수정이 완료 되었습니다.',
     });
+
+    setImagePreview('');
+    setSelectedFile('');
+    setUserData(upLoadData);
   };
 
   //파일 미리보기를 위한 state


### PR DESCRIPTION
## 📌 변경 사항
/componets/mypage/EditProFile 수정

- 

## 🛠️ 변경 이유 및 설명
<!-- 해당 변경 사항이 필요한 이유와 설명을 적어주세요. -->
프로필이지미 수정시 프로필수정사이트에 변경한 이미지가 동기화안되는 버그를 수정하였습니다


## ✅ 체크리스트
<!-- 아래 사항을 확인하고 체크해주세요. -->
- [ ] 관련된 이슈가 있습니다.
- [ ] 코드가 정상적으로 동작합니다.
- [ ] 테스트를 거쳤습니다.

